### PR TITLE
Add current time to each screen_say function

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -51,7 +51,7 @@ screen_saveon() {
 }
 
 screen_say() {
-	screen_command "say $1"
+	screen_command "say [$(date +%H:%M:%S)] $1"
 }
 
 online_backup() {


### PR DESCRIPTION
When the script broadcasts into server chat, it now includes the current server time by running the date as a command substitution under the screen_say function.